### PR TITLE
Made the Overwatch League module completely asynchronous

### DIFF
--- a/Modules/OverwatchLeague/src/Data/Database.cs
+++ b/Modules/OverwatchLeague/src/Data/Database.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Drawing;
 using System.Net;
 using System.Text;
@@ -10,11 +11,17 @@ using System.Threading.Tasks;
 namespace OverwatchLeague.Data {
 	public class Database {
 		private List<Team> teams;
+		public ReadOnlyCollection<Team> Teams { get { return teams.AsReadOnly(); } }
 		private List<Division> divisions;
+		public ReadOnlyCollection<Division> Divisions { get { return divisions.AsReadOnly(); } }
 		private List<Map> maps;
+		public ReadOnlyCollection<Map> Maps { get { return maps.AsReadOnly(); } }
 		private List<GameMode> gameModes;
+		public ReadOnlyCollection<GameMode> GameModes { get { return gameModes.AsReadOnly(); } }
 		private List<Match> matches;
+		public ReadOnlyCollection<Match> Matches { get { return matches.AsReadOnly(); } }
 		private List<Stage> stages;
+		public ReadOnlyCollection<Stage> Stages { get { return stages.AsReadOnly(); } }
 
 		public Database() {
 			teams = new List<Team>();

--- a/Modules/OverwatchLeague/src/Data/Database.cs
+++ b/Modules/OverwatchLeague/src/Data/Database.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.CSharp.RuntimeBinder;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OverwatchLeague.Data {
+	public class Database {
+		private List<Team> teams;
+		private List<Division> divisions;
+		private List<Map> maps;
+		private List<GameMode> gameModes;
+
+		public Database() {
+			teams = new List<Team>();
+			divisions = new List<Division>();
+			maps = new List<Map>();
+			gameModes = new List<GameMode>();
+		}
+
+		public void Clear() {
+			teams.Clear();
+			divisions.Clear();
+			maps.Clear();
+			gameModes.Clear();
+		}
+
+		public async Task ReloadDatabase() {
+			Clear();
+			await LoadTeamsAndDivisions();
+			await LoadMapsAndModes();
+		}
+
+		private async Task LoadTeamsAndDivisions() {
+			// Both teams and divisions are available through one API call.
+			using (var wc = new WebClient()) {
+				string teamsJsonString = await wc.DownloadStringTaskAsync("https://api.overwatchleague.com/teams");
+				dynamic teamsJson = JsonConvert.DeserializeObject(teamsJsonString);
+
+				// First note the divisions.
+				foreach (var division in teamsJson.owl_divisions) {
+					// The division ID is a string for some reason.
+					int id = int.Parse(division.id.Value);
+					string name = division.name;
+					string abbreviatedName = division.abbrev;
+					divisions.Add(new Division(id, name, abbreviatedName));
+				}
+
+				// Then note the teams, and then we'll link back to the divisions.
+				foreach (var competitor in teamsJson.competitors) {
+					var details = competitor.competitor; // The JSON has an additional hurdle for some reason.
+
+					// We need to handle the colors first.
+					Color primaryColor = Color.FromArgb(Convert.ToInt32(details.primaryColor.Value, 16));
+					Color secondaryColor = Color.FromArgb(Convert.ToInt32(details.secondaryColor.Value, 16));
+					int id = details.id;
+					string name = details.name;
+					string abbreviatedName = details.abbreviatedName;
+					Team newTeam = new Team(id, name, abbreviatedName, primaryColor, secondaryColor);
+					teams.Add(newTeam);
+
+					// Also do some linking here.
+					int divisionId = details.owl_division;
+					Division division = divisions.Find(d => d.Id == divisionId);
+					division.AddTeam(newTeam);
+					newTeam.SetDivision(division);
+				}
+			}
+		}
+
+		private async Task LoadMapsAndModes() {
+			using (var wc = new WebClient()) {
+				string mapsJsonString = await wc.DownloadStringTaskAsync("https://api.overwatchleague.com/maps");
+				dynamic mapsJson = JsonConvert.DeserializeObject(mapsJsonString);
+
+				// Just store the maps straight.
+				foreach (var map in mapsJson) {
+					// The division ID is a string for some reason.
+					ulong guid = Convert.ToUInt64(map.guid.Value, 16);
+					string name = map.name.en_US;
+
+					Map newMap = new Map(guid, name);
+					maps.Add(newMap);
+
+
+					if (map["gameModes"] != null) {
+						foreach (var gameMode in map.gameModes) {
+							ulong gameModeId = Convert.ToUInt64(gameMode.Id.Value, 16);
+							string modeName = gameMode.Name;
+
+							GameMode mode = gameModes.Find(m => m.Id == gameModeId);
+							if (mode == null) {
+								mode = new GameMode(gameModeId, modeName);
+								gameModes.Add(mode);
+							}
+							mode.AddMap(newMap);
+							newMap.AddGameMode(mode);
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/Database.cs
+++ b/Modules/OverwatchLeague/src/Data/Database.cs
@@ -242,5 +242,71 @@ namespace OverwatchLeague.Data {
 				}
 			}
 		}
+
+		public List<Standing> GetStandings(int stage = 0) {
+			List<int> stageIndiciesToUse;
+			if (stage >= 1 && stage <= 4) {
+				stageIndiciesToUse = new List<int> { stage - 1 };
+			} else {
+				stageIndiciesToUse = new List<int> { 0, 1, 2, 3 };
+			}
+
+			List<Standing> standings = new List<Standing>();
+			foreach (Team team in teams) {
+				Standing s = new Standing { Team = team };
+
+				foreach (int i in stageIndiciesToUse) {
+					foreach (Week week in stages[i].Weeks) {
+						foreach (Match match in week.Matches) {
+							if (match.Status == MatchStatus.Concluded) {
+								if (match.HomeTeam == team) {
+									s.MapWins += match.HomeScore;
+									s.MapDraws += match.DrawMaps;
+									s.MapLosses += match.AwayScore;
+									if (match.HomeScore > match.AwayScore) {
+										++s.MatchWins;
+									} else {
+										++s.MatchLosses;
+									}
+								} else if (match.AwayTeam == team) {
+									s.MapWins += match.AwayScore;
+									s.MapDraws += match.DrawMaps;
+									s.MapLosses += match.HomeScore;
+									if (match.AwayScore > match.HomeScore) {
+										++s.MatchWins;
+									} else {
+										++s.MatchLosses;
+									}
+								}
+							}
+						}
+					}
+				}
+				standings.Add(s);
+			}
+
+			standings.Sort((a, b) => {
+				if ((a.MatchWins - a.MatchLosses) == (b.MatchWins - b.MatchLosses)) {
+					return b.MapDiff.CompareTo(a.MapDiff);
+				} else {
+					return (b.MatchWins - b.MatchLosses).CompareTo(a.MatchWins - a.MatchLosses);
+				}
+			});
+
+			int lastPosition = 1;
+			for (int i = 1; i <= teams.Count; ++i) {
+				Standing newStanding = standings[i - 1];
+				if (i == 1 || ((standings[i - 2].MapWins - standings[i - 2].MapLosses) == (standings[i - 1].MapWins - standings[i - 1].MapLosses) && standings[i - 2].MapDiff == standings[i - 1].MapDiff)) {
+					newStanding.Position = lastPosition;
+					standings[i - 1] = newStanding;
+				} else {
+					newStanding.Position = i;
+					standings[i - 1] = newStanding;
+					lastPosition = i;
+				}
+			}
+
+			return standings;
+		}
 	}
 }

--- a/Modules/OverwatchLeague/src/Data/Division.cs
+++ b/Modules/OverwatchLeague/src/Data/Division.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public class Division {
+		public int Id { get; private set; }
+		public string Name { get; private set; }
+		public string AbbreviatedName { get; private set; }
+		private List<Team> teams;
+		public ReadOnlyCollection<Team> Teams { get { return teams.AsReadOnly(); } }
+
+		public Division(int id, string name, string abbreviatedName) {
+			Id = id;
+			Name = name;
+			AbbreviatedName = abbreviatedName;
+			teams = new List<Team>();
+		}
+
+		public void AddTeam(Team t) {
+			teams.Add(t);
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/GameMode.cs
+++ b/Modules/OverwatchLeague/src/Data/GameMode.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public class GameMode {
+		public ulong Id { get; private set; }
+		public string Name { get; private set; }
+		private List<Map> maps;
+		public ReadOnlyCollection<Map> Maps { get { return maps.AsReadOnly(); } }
+
+		public GameMode(ulong id, string name) {
+			Id = id;
+			Name = name;
+			maps = new List<Map>();
+		}
+
+		public void AddMap(Map map) {
+			maps.Add(map);
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/Map.cs
+++ b/Modules/OverwatchLeague/src/Data/Map.cs
@@ -9,15 +9,22 @@ namespace OverwatchLeague.Data {
 		public string Name { get; private set; }
 		private List<GameMode> gameModes;
 		public ReadOnlyCollection<GameMode> GameModes { get { return gameModes.AsReadOnly(); } }
+		private List<MatchGame> games;
+		public ReadOnlyCollection<MatchGame> Games { get { return games.AsReadOnly(); } }
 
 		public Map(ulong guid, string name) {
 			Guid = guid;
 			Name = name;
 			gameModes = new List<GameMode>();
+			games = new List<MatchGame>();
 		}
 
 		public void AddGameMode(GameMode mode) {
 			gameModes.Add(mode);
+		}
+
+		public void AddGame(MatchGame game) {
+			games.Add(game);
 		}
 	}
 }

--- a/Modules/OverwatchLeague/src/Data/Map.cs
+++ b/Modules/OverwatchLeague/src/Data/Map.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public class Map {
+		public ulong Guid { get; private set; }
+		public string Name { get; private set; }
+		private List<GameMode> gameModes;
+		public ReadOnlyCollection<GameMode> GameModes { get { return gameModes.AsReadOnly(); } }
+
+		public Map(ulong guid, string name) {
+			Guid = guid;
+			Name = name;
+			gameModes = new List<GameMode>();
+		}
+
+		public void AddGameMode(GameMode mode) {
+			gameModes.Add(mode);
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/Match.cs
+++ b/Modules/OverwatchLeague/src/Data/Match.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public class Match {
+		public int Id { get; private set; }
+		public Team HomeTeam { get; private set; }
+		public Team AwayTeam { get; private set; }
+		public int HomeScore { get; private set; }
+		public int AwayScore { get; private set; }
+		private string status;
+		public MatchStatus Status { get { return MatchStatusExtensions.FromString(status); } }
+		public DateTime StartTime { get; private set; }
+		public DateTime EndTime { get; private set; }
+		public DateTime? ActualStartTime { get; private set; }
+		public DateTime? ActualEndTime { get; private set; }
+		private List<MatchGame> games;
+		public ReadOnlyCollection<MatchGame> Games { get { return games.AsReadOnly(); } }
+
+
+		public Match(int id, Team homeTeam, Team awayTeam, int homeScore, int awayScore, string status, DateTime startTime, DateTime endTime, DateTime? actualStartTime, DateTime? actualEndTime) {
+			Id = id;
+			HomeTeam = homeTeam;
+			AwayTeam = awayTeam;
+			HomeScore = homeScore;
+			AwayScore = awayScore;
+			this.status = status;
+			StartTime = startTime;
+			EndTime = endTime;
+			ActualStartTime = actualStartTime;
+			ActualEndTime = actualEndTime;
+
+			games = new List<MatchGame>();
+		}
+
+		public void AddGame(MatchGame game) {
+			games.Add(game);
+		}
+
+		public int TeamScore(Team team) {
+			if (team == HomeTeam) {
+				return HomeScore;
+			} else if (team == AwayTeam) {
+				return AwayScore;
+			} else {
+				return -1;
+			}
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/Match.cs
+++ b/Modules/OverwatchLeague/src/Data/Match.cs
@@ -44,6 +44,10 @@ namespace OverwatchLeague.Data {
 
 			updateTimer = new Timer();
 			updateTimer.Elapsed += UpdateTimer_Elapsed;
+			
+			// No point attempting to update the map if it won't start within 24 hours, since the whole
+			// DB is being updated anyways. This gets around a weird bug where the time start is more
+			// than int32Max ticks away.
 			if ((StartTime - DateTime.UtcNow) < TimeSpan.FromDays(1)) {
 				if (DateTime.UtcNow < StartTime) {
 					updateTimer.Interval = (StartTime - DateTime.UtcNow).TotalMilliseconds;

--- a/Modules/OverwatchLeague/src/Data/Match.cs
+++ b/Modules/OverwatchLeague/src/Data/Match.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text;
 
 namespace OverwatchLeague.Data {
@@ -10,6 +11,7 @@ namespace OverwatchLeague.Data {
 		public Team AwayTeam { get; private set; }
 		public int HomeScore { get; private set; }
 		public int AwayScore { get; private set; }
+		public int DrawMaps { get { return Games.Where(x => x.HomeScore == x.AwayScore).Count(); } }
 		private string status;
 		public MatchStatus Status { get { return MatchStatusExtensions.FromString(status); } }
 		public DateTime StartTime { get; private set; }

--- a/Modules/OverwatchLeague/src/Data/Match.cs
+++ b/Modules/OverwatchLeague/src/Data/Match.cs
@@ -1,8 +1,11 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Net;
 using System.Text;
+using System.Timers;
 
 namespace OverwatchLeague.Data {
 	public class Match : IComparable<Match> {
@@ -22,6 +25,7 @@ namespace OverwatchLeague.Data {
 		public ReadOnlyCollection<MatchGame> Games { get { return games.AsReadOnly(); } }
 		public Week Week { get; private set; }
 		public Stage Stage { get { return Week.Stage; } }
+		private Timer updateTimer;
 
 
 		public Match(int id, Team homeTeam, Team awayTeam, int homeScore, int awayScore, string status, DateTime startTime, DateTime endTime, DateTime? actualStartTime, DateTime? actualEndTime) {
@@ -37,6 +41,105 @@ namespace OverwatchLeague.Data {
 			ActualEndTime = actualEndTime;
 
 			games = new List<MatchGame>();
+
+			updateTimer = new Timer();
+			updateTimer.Elapsed += UpdateTimer_Elapsed;
+			if ((StartTime - DateTime.UtcNow) < TimeSpan.FromDays(1)) {
+				if (DateTime.UtcNow < StartTime) {
+					updateTimer.Interval = (StartTime - DateTime.UtcNow).TotalMilliseconds;
+					updateTimer.Enabled = true;
+				} else if (DateTime.UtcNow < EndTime) {
+					updateTimer.Interval = 1000 * 60;
+					updateTimer.Enabled = true;
+				}
+			} else {
+				updateTimer.Enabled = false;
+			}
+		}
+
+		private async void UpdateTimer_Elapsed(object sender, ElapsedEventArgs e) {
+			if (DateTime.UtcNow < StartTime) {
+				updateTimer.Interval = (StartTime - DateTime.UtcNow).TotalMilliseconds;
+				return;
+			} else if (DateTime.UtcNow < EndTime) {
+				updateTimer.Interval = 1000 * 60;
+
+				using (var wc = new WebClient()) {
+					string matchJsonString = await wc.DownloadStringTaskAsync($"https://api.overwatchleague.com/matches/{Id}");
+					dynamic matchJson = JsonConvert.DeserializeObject(matchJsonString);
+
+					if (HomeTeam == null && matchJson.competitors[0] != null) {
+						int teamId = matchJson.competitors[0].id;
+						HomeTeam = (from c in OverwatchLeague.Database.Teams where c.Id == teamId select c).First();
+					}
+
+					if (AwayTeam == null && matchJson.competitors[1] != null) {
+						int teamId = matchJson.competitors[1].id;
+						AwayTeam = (from c in OverwatchLeague.Database.Teams where c.Id == teamId select c).First();
+					}
+
+					if (matchJson["scores"] != null) {
+						HomeScore = matchJson.scores[0].value;
+						AwayScore = matchJson.scores[1].value;
+					}
+
+					status = matchJson.status;
+					StartTime = new DateTime(1970, 1, 1, 0, 0, 0).AddMilliseconds((double)matchJson.startDate);
+					EndTime = new DateTime(1970, 1, 1, 0, 0, 0).AddMilliseconds((double)matchJson.endDate);
+					if (matchJson["actualStartTime"] != null) {
+						ActualStartTime = new DateTime(1970, 1, 1, 0, 0, 0).AddMilliseconds((double)matchJson.actualStartTime);
+					}
+					if (matchJson["actualEndTime"] != null) {
+						ActualEndTime = new DateTime(1970, 1, 1, 0, 0, 0).AddMilliseconds((double)matchJson.actualEndTime);
+					}
+
+					foreach (var game in matchJson.games) {
+						int gameId = game.id;
+						MatchGame g = games.Find(x => x.Id == gameId);
+
+						if (g == null) {
+							int gameNumber = game.number;
+							int gameHomePoints = 0;
+							int gameAwayPoints = 0;
+							if (game["points"] != null) {
+								gameHomePoints = game.points[0];
+								gameAwayPoints = game.points[1];
+							}
+							ulong mapGuid = 0;
+							if (game["attributes"]["mapGuid"] != null) {
+								mapGuid = Convert.ToUInt64(game.attributes.mapGuid.Value, 16);
+							}
+							string gameStatus = game.status;
+							Map map = (from c in OverwatchLeague.Database.Maps where c.Guid == mapGuid select c).First();
+
+							g = new MatchGame(gameId, gameNumber, gameHomePoints, gameAwayPoints, this, map, gameStatus);
+
+							if (map != null) {
+								map.AddGame(g);
+							}
+							AddGame(g);
+						} else {
+							if (game["points"] != null) {
+								g.SetHomeScore(game.points[0]);
+								g.SetAwayScore(game.points[1]);
+							}
+							if (g.Map == null) {
+								ulong mapGuid = 0;
+								if (game["attributes"]["mapGuid"] != null) {
+									mapGuid = Convert.ToUInt64(game.attributes.mapGuid.Value, 16);
+								}
+								Map map = (from c in OverwatchLeague.Database.Maps where c.Guid == mapGuid select c).First();
+								g.SetMap(map);
+								if (map != null) {
+									map.AddGame(g);
+								}
+							}
+						}
+					}
+				}
+			} else {
+				updateTimer.Enabled = false;
+			}
 		}
 
 		public void AddGame(MatchGame game) {

--- a/Modules/OverwatchLeague/src/Data/Match.cs
+++ b/Modules/OverwatchLeague/src/Data/Match.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 using System.Text;
 
 namespace OverwatchLeague.Data {
-	public class Match {
+	public class Match : IComparable<Match> {
 		public int Id { get; private set; }
 		public Team HomeTeam { get; private set; }
 		public Team AwayTeam { get; private set; }
@@ -18,6 +18,8 @@ namespace OverwatchLeague.Data {
 		public DateTime? ActualEndTime { get; private set; }
 		private List<MatchGame> games;
 		public ReadOnlyCollection<MatchGame> Games { get { return games.AsReadOnly(); } }
+		public Week Week { get; private set; }
+		public Stage Stage { get { return Week.Stage; } }
 
 
 		public Match(int id, Team homeTeam, Team awayTeam, int homeScore, int awayScore, string status, DateTime startTime, DateTime endTime, DateTime? actualStartTime, DateTime? actualEndTime) {
@@ -47,6 +49,13 @@ namespace OverwatchLeague.Data {
 			} else {
 				return -1;
 			}
+		}
+
+		public void SetWeek(Week week) {
+			Week = week;
+		}
+		public int CompareTo(Match other) {
+			return StartTime.CompareTo(other.StartTime);
 		}
 	}
 }

--- a/Modules/OverwatchLeague/src/Data/MatchGame.cs
+++ b/Modules/OverwatchLeague/src/Data/MatchGame.cs
@@ -22,5 +22,21 @@ namespace OverwatchLeague.Data {
 			Map = map;
 			this.status = status;
 		}
+
+		public void SetHomeScore(int score) {
+			HomeScore = score;
+		}
+
+		public void SetAwayScore(int score) {
+			AwayScore = score;
+		}
+
+		public void SetMap(Map map) {
+			Map = map;
+		}
+
+		public void SetStatus(string status) {
+			this.status = status;
+		}
 	}
 }

--- a/Modules/OverwatchLeague/src/Data/MatchGame.cs
+++ b/Modules/OverwatchLeague/src/Data/MatchGame.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public class MatchGame {
+		public int Id { get; private set; }
+		public int MapNumber { get; private set; }
+		public int HomeScore { get; private set; }
+		public int AwayScore { get; private set; }
+		public Match Match { get; private set; }
+		public Map Map { get; private set; }
+		public string status { get; private set; }
+		public MatchStatus Status { get { return MatchStatusExtensions.FromString(status); } }
+
+		public MatchGame(int id, int mapNumber, int homeScore, int awayScore, Match match, Map map, string status) {
+			Id = id;
+			MapNumber = mapNumber;
+			HomeScore = homeScore;
+			AwayScore = awayScore;
+			Match = match;
+			Map = map;
+			this.status = status;
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/MatchStatus.cs
+++ b/Modules/OverwatchLeague/src/Data/MatchStatus.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public enum MatchStatus {
+		Unknown,
+		Pending,
+		InProgress,
+		Concluded
+	}
+
+	public static class MatchStatusExtensions {
+		public static MatchStatus FromString(string s) {
+			switch (s) {
+				case "PENDING":
+					return MatchStatus.Pending;
+				case "IN_PROGRESS":
+					return MatchStatus.InProgress;
+				case "CONCLUDED":
+					return MatchStatus.Concluded;
+				default:
+					return MatchStatus.Unknown;
+			}
+		}
+
+		public static string ToString(this MatchStatus ms) {
+			switch (ms) {
+				case MatchStatus.Unknown:
+				default:
+					return "???";
+				case MatchStatus.Pending:
+					return "PENDING";
+				case MatchStatus.InProgress:
+					return "IN_PROGRESS";
+				case MatchStatus.Concluded:
+					return "CONCLUDED";
+			}
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/Stage.cs
+++ b/Modules/OverwatchLeague/src/Data/Stage.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public class Stage {
+		public int StageNumber { get; private set; }
+		public string Name { get; private set; }
+		private List<Week> weeks;
+		public ReadOnlyCollection<Week> Weeks { get { return weeks.AsReadOnly(); } }
+		public Week Playoffs { get; private set; }
+
+		public Stage(int stageNumber, string name) {
+			StageNumber = stageNumber;
+			Name = name;
+			weeks = new List<Week>();
+			Playoffs = null;
+		}
+
+		public void AddWeek(Week week) {
+			weeks.Add(week);
+		}
+
+		public void SetPlayoffs(Week playoffWeek) {
+			Playoffs = playoffWeek;
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/Standing.cs
+++ b/Modules/OverwatchLeague/src/Data/Standing.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public struct Standing {
+		public int Position;
+		public Team Team;
+		public int MatchWins;
+		public int MatchLosses;
+		public int MapWins;
+		public int MapDraws;
+		public int MapLosses;
+		public int MapDiff { get { return MapWins - MapLosses; } }
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/Team.cs
+++ b/Modules/OverwatchLeague/src/Data/Team.cs
@@ -32,6 +32,9 @@ namespace OverwatchLeague.Data {
 
 		public void AddMatch(Match m) {
 			matches.Add(m);
+			matches.Sort((a, b) => {
+				return a.StartTime.CompareTo(b.StartTime);
+			});
 		}
 	}
 }

--- a/Modules/OverwatchLeague/src/Data/Team.cs
+++ b/Modules/OverwatchLeague/src/Data/Team.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Drawing;
 using System.Text;
 
@@ -12,6 +13,8 @@ namespace OverwatchLeague.Data {
 		public Division Division { get; private set; }
 		public Color PrimaryColor { get; private set; }
 		public Color SecondaryColor { get; private set; }
+		private List<Match> matches;
+		public ReadOnlyCollection<Match> Matches { get { return matches.AsReadOnly(); } }
 
 		public Team(int id, string name, string abbreviatedName, Color primaryColor, Color secondaryColor) {
 			Id = id;
@@ -20,10 +23,15 @@ namespace OverwatchLeague.Data {
 			Division = null;
 			PrimaryColor = primaryColor;
 			SecondaryColor = secondaryColor;
+			matches = new List<Match>();
 		}
 
 		public void SetDivision(Division d) {
 			Division = d;
+		}
+
+		public void AddMatch(Match m) {
+			matches.Add(m);
 		}
 	}
 }

--- a/Modules/OverwatchLeague/src/Data/Team.cs
+++ b/Modules/OverwatchLeague/src/Data/Team.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public class Team {
+		public int Id { get; private set; }
+		public string Name { get; private set; }
+		public string AbbreviatedName { get; private set; }
+		
+		public Division Division { get; private set; }
+		public Color PrimaryColor { get; private set; }
+		public Color SecondaryColor { get; private set; }
+
+		public Team(int id, string name, string abbreviatedName, Color primaryColor, Color secondaryColor) {
+			Id = id;
+			Name = name;
+			AbbreviatedName = abbreviatedName;
+			Division = null;
+			PrimaryColor = primaryColor;
+			SecondaryColor = secondaryColor;
+		}
+
+		public void SetDivision(Division d) {
+			Division = d;
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/Data/Week.cs
+++ b/Modules/OverwatchLeague/src/Data/Week.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace OverwatchLeague.Data {
+	public class Week {
+		public int WeekNumber { get; private set; }
+		public string Name { get; private set; }
+		public Stage Stage { get; private set; }
+		private List<Match> matches;
+		public ReadOnlyCollection<Match> Matches { get { return matches.AsReadOnly(); } }
+
+		public Week(int weekNumber, string name) {
+			WeekNumber = weekNumber;
+			Name = name;
+			Stage = null;
+			matches = new List<Match>();
+		}
+
+		public void AddMatch(Match match) {
+			matches.Add(match);
+		}
+
+		public void SetStage(Stage stage) {
+			Stage = stage;
+		}
+	}
+}

--- a/Modules/OverwatchLeague/src/OverwatchLeague.cs
+++ b/Modules/OverwatchLeague/src/OverwatchLeague.cs
@@ -4,6 +4,7 @@ using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using Microsoft.CSharp.RuntimeBinder;
 using Newtonsoft.Json;
+using OverwatchLeague.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,7 +30,14 @@ namespace OverwatchLeague {
 		private static Dictionary<string, string> MapNames;
 		private static Dictionary<string, string> MapModes;
 
+		private static Database database;
+
 		private static async Task<bool> Startup() {
+			if (database == null) {
+				database = new Database();
+			}
+			await database.ReloadDatabase();
+
 			MapNames = new Dictionary<string, string>();
 			MapModes = new Dictionary<string, string>();
 

--- a/Modules/OverwatchLeague/src/OverwatchLeague.cs
+++ b/Modules/OverwatchLeague/src/OverwatchLeague.cs
@@ -27,14 +27,14 @@ namespace OverwatchLeague {
 			OnMessage = OverwatchLeagueCommand
 		};
 
-		private static Database database;
+		public static Database Database;
 
 		private static async Task<bool> Startup() {
-			if (database == null) {
-				database = new Database();
+			if (Database == null) {
+				Database = new Database();
 			}
 			try {
-				await database.ReloadDatabase();
+				await Database.ReloadDatabase();
 			} catch (Exception exc) {
 				Console.Error.WriteLine(exc);
 				return false;
@@ -85,7 +85,7 @@ namespace OverwatchLeague {
 
 			using (var wc = new WebClient()) {
 				if (splitMessage.Length > 1 && splitMessage[1] == "live") {
-					Match match = (from c in database.Matches where c.EndTime > DateTime.UtcNow select c).First();
+					Match match = (from c in Database.Matches where c.EndTime > DateTime.UtcNow select c).First();
 
 					if (match == null) {
 						await Methods.SendMessage(null, new SendMessageEventArgs {
@@ -101,7 +101,7 @@ namespace OverwatchLeague {
 						});
 					}
 				} else if (splitMessage.Length > 1 && splitMessage[1] == "next") {
-					Match match = (from c in database.Matches where c.StartTime > DateTime.UtcNow select c).First();
+					Match match = (from c in Database.Matches where c.StartTime > DateTime.UtcNow select c).First();
 
 					if (match == null) {
 						await Methods.SendMessage(null, new SendMessageEventArgs {
@@ -124,7 +124,7 @@ namespace OverwatchLeague {
 					sb.AppendLine(" # |                         Name | W - L | Diff |   Map W-D-L");
 					sb.AppendLine("---+------------------------------+-------+------+------------");
 
-					foreach (Standing s in database.GetStandings()) {
+					foreach (Standing s in Database.GetStandings()) {
 						sb.AppendLine($"{s.Position.ToString().PadLeft(2, ' ')} | {s.Team.Name.ToString().PadLeft(22, ' ')} ({s.Team.AbbreviatedName}) | {s.MatchWins.ToString().PadLeft(2, ' ')}-{s.MatchLosses.ToString().PadLeft(2, ' ')} | {$"{(s.MapDiff > 0 ? '+' : ' ')}{s.MapDiff}".PadLeft(4, ' ')} | {s.MapWins.ToString().PadLeft(3, ' ')}-{s.MapDraws.ToString().PadLeft(3, ' ')}-{s.MapLosses.ToString().PadLeft(3, ' ')}");
 					}
 
@@ -144,9 +144,9 @@ namespace OverwatchLeague {
 						Week relevantWeek;
 
 						if (splitMessage[3] == "playoffs") {
-							relevantWeek = database.Stages[stage - 1].Playoffs;
+							relevantWeek = Database.Stages[stage - 1].Playoffs;
 						} else {
-							relevantWeek = database.Stages[stage - 1].Weeks[week - 1];
+							relevantWeek = Database.Stages[stage - 1].Weeks[week - 1];
 						}
 
 						foreach (Match match in relevantWeek.Matches) {
@@ -179,7 +179,7 @@ namespace OverwatchLeague {
 						});
 					} else if (splitMessage.Length > 2 && splitMessage[2].Length == 3) {
 						string teamName = splitMessage[2].ToUpper();
-						Team team = (from c in database.Teams where c.AbbreviatedName == teamName select c).First();
+						Team team = (from c in Database.Teams where c.AbbreviatedName == teamName select c).First();
 
 						if (team == null) {
 							await Methods.SendMessage(null, new SendMessageEventArgs {

--- a/Modules/OverwatchLeague/src/OverwatchLeague.cs
+++ b/Modules/OverwatchLeague/src/OverwatchLeague.cs
@@ -117,9 +117,6 @@ namespace OverwatchLeague {
 						});
 					}
 				} else if (splitMessage.Length > 1 && splitMessage[1] == "standings") {
-					string standingsJsonString = await wc.DownloadStringTaskAsync("https://api.overwatchleague.com/standings");
-					dynamic standingsJson = JsonConvert.DeserializeObject(standingsJsonString);
-
 					var sb = new StringBuilder();
 
 					sb.Append("```");
@@ -127,12 +124,8 @@ namespace OverwatchLeague {
 					sb.AppendLine(" # |                         Name | W - L | Diff |   Map W-D-L");
 					sb.AppendLine("---+------------------------------+-------+------+------------");
 
-					var rankingIndicies = Enumerable.Range(0, 20).ToList().ConvertAll(delegate (int i) { return i.ToString(); });
-
-					foreach (var index in rankingIndicies) {
-						var team = standingsJson.ranks.content[index];
-						var mapDiff = team.records[0].gameWin - team.records[0].gameLoss;
-						sb.AppendLine($"{team.placement.ToString().PadLeft(2, ' ')} | {team.competitor.name.ToString().PadLeft(22, ' ')} ({team.competitor.abbreviatedName}) | {team.records[0].matchWin.ToString().PadLeft(2, ' ')}-{team.records[0].matchLoss.ToString().PadLeft(2, ' ')} | {$"{(mapDiff > 0 ? '+' : ' ')}{mapDiff}".PadLeft(4, ' ')} | {team.records[0].gameWin.ToString().PadLeft(3, ' ')}-{team.records[0].gameTie.ToString().PadLeft(3, ' ')}-{team.records[0].gameLoss.ToString().PadLeft(3, ' ')}");
+					foreach (Standing s in database.GetStandings()) {
+						sb.AppendLine($"{s.Position.ToString().PadLeft(2, ' ')} | {s.Team.Name.ToString().PadLeft(22, ' ')} ({s.Team.AbbreviatedName}) | {s.MatchWins.ToString().PadLeft(2, ' ')}-{s.MatchLosses.ToString().PadLeft(2, ' ')} | {$"{(s.MapDiff > 0 ? '+' : ' ')}{s.MapDiff}".PadLeft(4, ' ')} | {s.MapWins.ToString().PadLeft(3, ' ')}-{s.MapDraws.ToString().PadLeft(3, ' ')}-{s.MapLosses.ToString().PadLeft(3, ' ')}");
 					}
 
 					sb.Append("```");

--- a/Modules/OverwatchLeague/src/OverwatchLeague.cs
+++ b/Modules/OverwatchLeague/src/OverwatchLeague.cs
@@ -27,7 +27,7 @@ namespace OverwatchLeague {
 			OnMessage = OverwatchLeagueCommand
 		};
 
-		public static Database Database;
+		internal static Database Database;
 
 		private static async Task<bool> Startup() {
 			if (Database == null) {

--- a/Modules/OverwatchLeague/src/OverwatchLeague.cs
+++ b/Modules/OverwatchLeague/src/OverwatchLeague.cs
@@ -22,7 +22,7 @@ namespace OverwatchLeague {
 			Description = "Tells you up-to-date stats about the Overwatch League.",
 			Usage = $"Usage:\n{"?overwatchleague live".Code()} {"(stats about the match that is currently on)".Italics()}\n{"?overwatchleague next".Code()} {"(stats about the next match that will be played)".Italics()}\n{"?overwatchleague standings".Code()} {"(the overall standings of the league)".Italics()}\n{"?overwatchleague schedule [stage] [week]".Code()} {"(shows times and scores for each match in the given week)".Italics()}\n{"?overwatchleague schedule [stage] playoffs".Code()} {"(shows times and scores for each match in the given stage's playoffs)".Italics()}\n{"?overwatchleague schedule [abbreviated team name]".Code()} {"(shows times and scores for each match that a team plays)".Italics()}\nAll times listed are in UTC.",
 			Author = "Biendeo",
-			Version = "0.4.0",
+			Version = "1.0.0",
 			Startup = Startup,
 			OnMessage = OverwatchLeagueCommand
 		};
@@ -85,7 +85,7 @@ namespace OverwatchLeague {
 
 			using (var wc = new WebClient()) {
 				if (splitMessage.Length > 1 && splitMessage[1] == "live") {
-					Match match = (from c in Database.Matches where c.EndTime > DateTime.UtcNow select c).First();
+					Match match = (from c in Database.Matches where c.EndTime > DateTime.UtcNow && c.StartTime < DateTime.UtcNow select c).FirstOrDefault();
 
 					if (match == null) {
 						await Methods.SendMessage(null, new SendMessageEventArgs {
@@ -101,7 +101,7 @@ namespace OverwatchLeague {
 						});
 					}
 				} else if (splitMessage.Length > 1 && splitMessage[1] == "next") {
-					Match match = (from c in Database.Matches where c.StartTime > DateTime.UtcNow select c).First();
+					Match match = (from c in Database.Matches where c.StartTime > DateTime.UtcNow select c).FirstOrDefault();
 
 					if (match == null) {
 						await Methods.SendMessage(null, new SendMessageEventArgs {
@@ -152,9 +152,9 @@ namespace OverwatchLeague {
 						foreach (Match match in relevantWeek.Matches) {
 							sb.Append($"{match.StartTime.ToString("d/MM hh:mm tt").PadLeft(15, ' ')} UTC - ");
 							if (match.HomeTeam != null) {
-								sb.Append($"{match.HomeTeam.AbbreviatedName} - ");
+								sb.Append($"{match.HomeTeam.AbbreviatedName} vs. ");
 							} else {
-								sb.Append("??? - ");
+								sb.Append("??? vs. ");
 							}
 							if (match.AwayTeam != null) {
 								sb.Append($"{match.AwayTeam.AbbreviatedName}");
@@ -179,7 +179,7 @@ namespace OverwatchLeague {
 						});
 					} else if (splitMessage.Length > 2 && splitMessage[2].Length == 3) {
 						string teamName = splitMessage[2].ToUpper();
-						Team team = (from c in Database.Teams where c.AbbreviatedName == teamName select c).First();
+						Team team = (from c in Database.Teams where c.AbbreviatedName == teamName select c).FirstOrDefault();
 
 						if (team == null) {
 							await Methods.SendMessage(null, new SendMessageEventArgs {


### PR DESCRIPTION
The Overwatch League module should now query the API a few times at startup and every 24 hours, as well as a small request whenever a match is currently live. This should reduce the number of API calls by far and provide much quicker responses at the cost of memory (but it's quite bearable).