### PR TITLE
Add repeat functionality to RemindMe

### DIFF
--- a/BlendoBot/BlendoBot.csproj
+++ b/BlendoBot/BlendoBot.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Salaros.ConfigParser" Version="0.3.3" />
+    <PackageReference Include="Salaros.ConfigParser" Version="0.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BlendoBot/src/Commands/Admin/Admin.cs
+++ b/BlendoBot/src/Commands/Admin/Admin.cs
@@ -354,27 +354,5 @@ namespace BlendoBot.Commands.Admin {
 
 		public string UnknownCommandPrefix => OtherSettings.UnknownCommandPrefix;
 		public bool IsUnknownCommandEnabled => OtherSettings.IsUnknownCommandEnabled;
-
-		public bool DisableCommand(string term) {
-			if (!IsCommandTermDisabled(term)) {
-				//TODO: Get the command class name.
-				//TODO: Remove the command.
-				SaveData();
-				return true;
-			} else {
-				return false;
-			}
-		}
-
-		public bool EnableCommandTerm(string term) {
-			if (IsCommandTermDisabled(term)) {
-				disabledCommands.RemoveAll(dc => dc.Term == term);
-				//TODO: Instantiate the command again.
-				SaveData();
-				return true;
-			} else {
-				return false;
-			}
-		}
 	}
 }

--- a/BlendoBot/src/Program.cs
+++ b/BlendoBot/src/Program.cs
@@ -428,14 +428,14 @@ namespace BlendoBot {
 			int messageListenerCount = 0;
 			int reactionListenerCount = 0;
 			if (GuildMessageListeners.ContainsKey(guildId)) {
-				foreach (var messageListener in GuildMessageListeners[guildId].Where(ml => ml.Command == command)) {
+				foreach (var messageListener in GuildMessageListeners[guildId].Where(ml => ml.Command == command).ToList()) {
 					RemoveMessageListener(o, guildId, messageListener);
 					++messageListenerCount;
 				}
 			}
 			if (MessageReactionListeners.ContainsKey(guildId)) {
-				foreach (var messageId in MessageReactionListeners[guildId].Keys) {
-					foreach (var reactionListener in MessageReactionListeners[guildId][messageId].Where(rl => rl.Command == command)) {
+				foreach (var messageId in MessageReactionListeners[guildId].Keys.ToList()) {
+					foreach (var reactionListener in MessageReactionListeners[guildId][messageId].Where(rl => rl.Command == command).ToList()) {
 						RemoveReactionListener(o, guildId, messageId, reactionListener);
 						++reactionListenerCount;
 					}

--- a/BlendoBot/src/Program.cs
+++ b/BlendoBot/src/Program.cs
@@ -174,7 +174,10 @@ namespace BlendoBot {
 			string logMessage = $"[{typeString}] ({DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")}) [{sender?.GetType().FullName ?? "null"}] | {e.Message}";
 			Console.WriteLine(logMessage);
 			if (!Directory.Exists("log")) Directory.CreateDirectory("log");
-			File.AppendAllText(LogFile, logMessage + "\n");
+			using (var logStream = File.Open(LogFile, FileMode.Append, FileAccess.Write, FileShare.ReadWrite)) {
+				using var writer = new StreamWriter(logStream);
+				writer.WriteLine(logMessage);
+			}
 		}
 		public string ReadConfig(object o, string configHeader, string configKey) {
 			return Config.ReadString(o, configHeader, configKey);
@@ -240,7 +243,7 @@ namespace BlendoBot {
 		/// <returns></returns>
 		public T GetCommand<T>(object sender, ulong guildId) where T : CommandBase {
 			if (GuildCommands.ContainsKey(guildId)) {
-				return GuildCommands[guildId].First(c => c.Value is T).Value as T;
+				return GuildCommands[guildId].FirstOrDefault(c => c.Value is T).Value as T;
 			}
 			return null;
 		}

--- a/BlendoBotLib/BlendoBotLib.csproj
+++ b/BlendoBotLib/BlendoBotLib.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00656" />
+    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00711" />
   </ItemGroup>
 
 </Project>

--- a/BlendoBotLib/src/IBotMethods.cs
+++ b/BlendoBotLib/src/IBotMethods.cs
@@ -56,6 +56,16 @@ namespace BlendoBotLib {
 		void RemoveMessageListener(object o, ulong guildId, IMessageListener messageListener);
 
 		/// <summary>
+		/// Adds a reaction listener to the program for this command.
+		/// </summary>
+		void AddReactionListener(object o, ulong guildId, ulong messageId, IReactionListener reactionListener);
+
+		/// <summary>
+		/// Removes a message listener from the program for this command.
+		/// </summary>
+		void RemoveReactionListener(object o, ulong guildId, ulong messageId, IReactionListener reactionListener);
+
+		/// <summary>
 		/// Gets an instance of a command for the given guildId.
 		/// </summary>
 		T GetCommand<T>(object o, ulong guildId) where T : CommandBase;
@@ -87,5 +97,10 @@ namespace BlendoBotLib {
 		/// Given a channel ID, returns the channel object.
 		/// </summary>
 		Task<DiscordChannel> GetChannel(object o, ulong channelId);
+
+		/// <summary>
+		/// Given a user ID, returns the user object.
+		/// </summary>
+		Task<DiscordUser> GetUser(object o, ulong userId);
 	}
 }

--- a/BlendoBotLib/src/IReactionListener.cs
+++ b/BlendoBotLib/src/IReactionListener.cs
@@ -1,0 +1,14 @@
+﻿using DSharpPlus.EventArgs;
+using System.Threading.Tasks;
+
+namespace BlendoBotLib {
+	/// <summary>
+	/// The public interface for a reaction listener. All reaction listeners must implement this.
+	/// </summary>
+	public interface IReactionListener {
+
+		Task OnReactionAdd(MessageReactionAddEventArgs e);
+
+		CommandBase Command { get; }
+	}
+}

--- a/Modules/RemindMe/RemindMe.csproj
+++ b/Modules/RemindMe/RemindMe.csproj
@@ -5,6 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.7" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\BlendoBotLib\BlendoBotLib.csproj" />
     <ProjectReference Include="..\UserTimeZone\UserTimeZone.csproj" />
   </ItemGroup>

--- a/Modules/RemindMe/src/Reminder.cs
+++ b/Modules/RemindMe/src/Reminder.cs
@@ -1,6 +1,7 @@
 ﻿using DSharpPlus.Entities;
 using Newtonsoft.Json;
 using System;
+using System.Text.RegularExpressions;
 using System.Timers;
 
 namespace RemindMe {
@@ -10,19 +11,27 @@ namespace RemindMe {
 		public DateTime Time { get; set; }
 		[JsonProperty(Required = Required.Always)]
 		public string Message { get; set; }
+		/// <summary>
+		/// This just removes any Discord syntax on @ messages so that certain commands don't needlessly ping.
+		/// </summary>
+		public string SanitizedMessage => Regex.Replace(Message, @"<@!(\d+)>", m => $"@{m.Groups[1].Value}");
 		[JsonProperty(Required = Required.Always)]
 		public ulong ChannelId { get; set; }
 		[JsonProperty(Required = Required.Always)]
 		public ulong UserId { get; set; }
+		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+		public ulong Frequency { get; set; } = 0ul;
+		public bool IsRepeating => Frequency > 0ul;
 		public Timer CallbackTimer { get; set; }
 
 		protected Reminder() {}
 
-		public Reminder(DateTime time, string message, ulong channelId, ulong userId) {
+		public Reminder(DateTime time, string message, ulong channelId, ulong userId, ulong frequency) {
 			Time = time;
 			Message = message;
 			ChannelId = channelId;
 			UserId = userId;
+			Frequency = frequency;
 			CallbackTimer = null;
 		}
 

--- a/Modules/RemindMe/src/ReminderDatabaseContext.cs
+++ b/Modules/RemindMe/src/ReminderDatabaseContext.cs
@@ -21,5 +21,9 @@ namespace RemindMe {
 				return SettingsSet.Single();
 			}
 		}
+		protected override void OnModelCreating(ModelBuilder modelBuilder) {
+			base.OnModelCreating(modelBuilder);
+			modelBuilder.Entity<Reminder>().Property(r => r.Time).HasConversion(t => t, t => DateTime.SpecifyKind(t, DateTimeKind.Utc));
+		}
 	}
 }

--- a/Modules/RemindMe/src/ReminderDatabaseContext.cs
+++ b/Modules/RemindMe/src/ReminderDatabaseContext.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RemindMe {
+	public class ReminderDatabaseContext : DbContext {
+		public ReminderDatabaseContext(DbContextOptions<ReminderDatabaseContext> options) : base(options) { }
+		public DbSet<Reminder> Reminders { get; set; }
+		private DbSet<Settings> SettingsSet { get; set; }
+		public Settings Settings {
+			get {
+				if (SettingsSet.Count() == 0) {
+					SettingsSet.Add(new Settings() {
+						MinimumRepeatTime = 300ul,
+						MaximumRemindersPerPerson = 20
+					});
+					SaveChanges();
+				}
+				return SettingsSet.Single();
+			}
+		}
+	}
+}

--- a/Modules/RemindMe/src/ReminderListListener.cs
+++ b/Modules/RemindMe/src/ReminderListListener.cs
@@ -1,0 +1,204 @@
+﻿using BlendoBotLib;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using DSharpPlus.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Timers;
+
+namespace RemindMe {
+	public class ReminderListListener : IReactionListener, IDisposable {
+		private const int RemindersPerPage = 10;
+		private static readonly DiscordEmoji[] DigitEmojis = new string[] { "0️⃣", "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣" }.Select(e => DiscordEmoji.FromUnicode(e)).ToArray();
+		private static readonly DiscordEmoji[] ArrowEmojis = new string[] { "⬅", "➡" }.Select(e => DiscordEmoji.FromUnicode(e)).ToArray();
+		private static DiscordEmoji LeftArrowEmoji => ArrowEmojis[0];
+		private static DiscordEmoji RightArrowEmoji => ArrowEmojis[1];
+		private DiscordEmoji[] ValidReactions => DigitEmojis.Take(NumberOfRemindersOnPage).Concat(ArrowEmojis).ToArray();
+
+		private readonly RemindMe remindMe;
+		private readonly DiscordChannel channel;
+		private readonly DiscordUser user;
+		private DiscordMessage message;
+		private readonly List<Reminder> scopedReminders;
+		private readonly TimeZoneInfo userTimeZone;
+		private readonly bool showUsernames;
+		private int page;
+		private Timer timeoutTimer;
+		private bool CanGoLeftPage => page > 0;
+		private bool CanGoRightPage => (page + 1) * RemindersPerPage < scopedReminders.Count;
+		private int NumberOfRemindersOnPage => Math.Min(scopedReminders.Count - page * RemindersPerPage, RemindersPerPage);
+
+		public CommandBase Command => remindMe;
+
+		public ReminderListListener(RemindMe remindMe, DiscordChannel channel, DiscordUser user, IEnumerable<Reminder> scopedReminders, TimeZoneInfo userTimeZone, bool showUsernames) {
+			this.remindMe = remindMe;
+			this.user = user;
+			this.channel = channel;
+			message = null;
+			this.scopedReminders = scopedReminders.ToList();
+			this.userTimeZone = userTimeZone;
+			this.showUsernames = showUsernames;
+			page = 0;
+			timeoutTimer = new Timer(60000.0);
+			timeoutTimer.Elapsed += TimeoutElapsed;
+		}
+
+		private async void TimeoutElapsed(object sender, ElapsedEventArgs e) {
+			remindMe.BotMethods.Log(this, new LogEventArgs {
+				Message = $"RemindListListener for message {message.Id} timed out and is disposing",
+				Type = LogType.Log
+			});
+			await DisposeSelf();
+		}
+
+		private async Task DisposeSelf() {
+			if (message != null) {
+				remindMe.BotMethods.RemoveReactionListener(this, channel.GuildId, message.Id, this);
+				foreach (var emoji in ValidReactions) {
+					await message.DeleteOwnReactionAsync(emoji);
+				}
+			}
+		}
+
+		private string GenerateMessage() {
+			if (scopedReminders.Count == 0) {
+				return "There are no reminders to view!";
+			}
+			var sb = new StringBuilder();
+
+			sb.AppendLine($"Viewing reminders {page * RemindersPerPage + 1}-{page * RemindersPerPage + NumberOfRemindersOnPage} of {scopedReminders.Count}");
+			for (int i = 0; i < NumberOfRemindersOnPage; ++i) {
+				var reminder = scopedReminders[page * RemindersPerPage + i];
+				string message = reminder.Message;
+				if (message.Length > 50) {
+					message = $"{message.Substring(0, 47)}...";
+				}
+				sb.Append($"{DigitEmojis[i]} - ");
+				if (showUsernames) {
+					sb.Append($"{reminder.User.Mention} in ");
+				}
+				sb.AppendLine($"{reminder.Channel.Mention} - \"{message}\"");
+				sb.Append($"Alerts at {TimeZoneInfo.ConvertTime(reminder.Time, userTimeZone).ToString(RemindMe.TimeFormatString)}");
+				if (reminder.IsRepeating) {
+					sb.Append(" ");
+					sb.Append($"(repeats at {TimeZoneInfo.ConvertTime(reminder.Time.AddSeconds(reminder.Frequency), userTimeZone).ToString(RemindMe.TimeFormatString)} every {reminder.FrequencyString})".Italics());
+				}
+				sb.AppendLine();
+			}
+			sb.Append($"React with ");
+			if (CanGoLeftPage) {
+				sb.Append(LeftArrowEmoji);
+				if (CanGoRightPage) {
+					sb.Append(" or ");
+				}
+			}
+			if (CanGoRightPage) {
+				sb.Append(RightArrowEmoji);
+			}
+			if (CanGoLeftPage || CanGoRightPage) {
+				sb.Append(" to view other pages, or ");
+			}
+			sb.Append(DigitEmojis.First());
+			if (NumberOfRemindersOnPage > 1) {
+				sb.AppendLine($" to {DigitEmojis[NumberOfRemindersOnPage - 1]} to delete that number reminder.");
+			} else {
+				sb.AppendLine(" to delete that reminder.");
+			}
+
+			return sb.ToString();
+		}
+
+		public async Task CreateMessage() {
+			message = await remindMe.BotMethods.SendMessage(this, new SendMessageEventArgs {
+				Message = "Loading reminders...",
+				LogMessage = "RemindListCreate",
+				Channel = channel
+			});
+			await UpdateMessage();
+			remindMe.BotMethods.AddReactionListener(this, channel.GuildId, message.Id, this);
+			if (scopedReminders.Count == 0) {
+				await DisposeSelf();
+			} else {
+				timeoutTimer.Start();
+			}
+		}
+
+		private async Task UpdateMessage() {
+			await message.ModifyAsync(GenerateMessage());
+			await UpdateReactions();
+			if (scopedReminders.Count == 0) {
+				await DisposeSelf();
+			}
+		}
+
+		private async Task UpdateReactions() {
+			if (message != null) {
+				try {
+					await message.DeleteAllReactionsAsync("Clearing all reactions for page update");
+				} catch (UnauthorizedException) {
+					remindMe.BotMethods.Log(this, new LogEventArgs {
+						Message = $"ReminderList tried clearing reactions, but couldn't because it doesn't have permission. An alternative method will be used but only this bot's reactions will be removed.",
+						Type = LogType.Warning
+					});
+					foreach (var reaction in message.Reactions) {
+						if (reaction.IsMe) {
+							await message.DeleteOwnReactionAsync(reaction.Emoji);
+						}
+					}
+				}
+				if (CanGoLeftPage) {
+					await message.CreateReactionAsync(LeftArrowEmoji);
+				}
+				for (int i = 0; i < NumberOfRemindersOnPage; ++i) {
+					await message.CreateReactionAsync(DigitEmojis[i]);
+				}
+				if (CanGoRightPage) {
+					await message.CreateReactionAsync(RightArrowEmoji);
+				}
+			}
+		}
+
+		public async Task OnReactionAdd(MessageReactionAddEventArgs e) {
+			if (e.User.Id == user.Id && ValidReactions.Contains(e.Emoji)) {
+				if (e.Emoji == LeftArrowEmoji) {
+					if (CanGoLeftPage) {
+						--page;
+					}
+				} else if (e.Emoji == RightArrowEmoji) {
+					if (CanGoRightPage) {
+						++page;
+					}
+				} else {
+					int index = DigitEmojis.ToList().IndexOf(e.Emoji);
+					var reminder = scopedReminders[index + RemindersPerPage * page];
+					scopedReminders.Remove(reminder);
+					remindMe.DeleteReminder(reminder);
+					if (page > 0 && NumberOfRemindersOnPage <= 0) {
+						--page;
+					}
+				}
+				timeoutTimer.Stop();
+				timeoutTimer.Start();
+				await UpdateMessage();
+			} else {
+				await message.DeleteReactionAsync(e.Emoji, e.User, "Invalid reaction to reminder list");
+			}
+		}
+
+		public void Dispose() {
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing) {
+			if (disposing) {
+				if (timeoutTimer != null) {
+					timeoutTimer.Dispose();
+				}
+			}
+		}
+	}
+}

--- a/Modules/RemindMe/src/ReminderListListener.cs
+++ b/Modules/RemindMe/src/ReminderListListener.cs
@@ -200,7 +200,14 @@ namespace RemindMe {
 				timeoutTimer.Start();
 				await UpdateMessage();
 			} else {
-				await message.DeleteReactionAsync(e.Emoji, e.User, "Invalid reaction to reminder list");
+				try {
+					await message.DeleteReactionAsync(e.Emoji, e.User, "Invalid reaction to reminder list");
+				} catch (UnauthorizedException) {
+					remindMe.BotMethods.Log(this, new LogEventArgs {
+						Message = $"ReminderList tried clearing reactions, but couldn't because it doesn't have permission. The user must clear their own reaction.",
+						Type = LogType.Warning
+					});
+				}
 			}
 		}
 

--- a/Modules/RemindMe/src/Settings.cs
+++ b/Modules/RemindMe/src/Settings.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RemindMe {
+	public class Settings {
+		[JsonProperty(Required = Required.Always)]
+		public ulong MinimumRepeatTime { get; set; }
+		[JsonProperty(Required = Required.Always)]
+		public int MaximumRemindersPerPerson { get; set; }
+	}
+}

--- a/Modules/RemindMe/src/Settings.cs
+++ b/Modules/RemindMe/src/Settings.cs
@@ -1,13 +1,13 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 
 namespace RemindMe {
 	public class Settings {
-		[JsonProperty(Required = Required.Always)]
+		[Key]
+		public int SettingsId { get; set; }
 		public ulong MinimumRepeatTime { get; set; }
-		[JsonProperty(Required = Required.Always)]
 		public int MaximumRemindersPerPerson { get; set; }
 	}
 }


### PR DESCRIPTION
This PR adds the ability for the RemindMe command to set up commands to be repeated. This also enables users to view their outstanding reminders and delete them via another command, which uses a new ReactionListener interface.

This PR is also a proof of concept for using Entity Framework and SQLite as a database format instead of JSON files. This'll be useful for other modules such as Mr Ping or UserTimeZone where users can freely store data for future usage.